### PR TITLE
Feature/expand hasgroup to oauth group

### DIFF
--- a/src/main/java/com/simisinc/platform/ApplicationInfo.java
+++ b/src/main/java/com/simisinc/platform/ApplicationInfo.java
@@ -32,7 +32,7 @@ public class ApplicationInfo {
   // Use: Change the date, increment the decimal on same day updates
   // then reset back to 10000
   //                         VERSION = "--------.10000";
-  public static final String VERSION = "20240411.10000";
+  public static final String VERSION = "20240413.10000";
 
   /**
    * Outputs the version from the command line

--- a/src/main/java/com/simisinc/platform/domain/model/User.java
+++ b/src/main/java/com/simisinc/platform/domain/model/User.java
@@ -346,6 +346,10 @@ public class User extends Entity {
       if (group.getUniqueId().equals(groupUniqueId)) {
         return true;
       }
+      // If SSO is enabled, then also check against the "OAUTH" value in the group...
+      if (StringUtils.isNotBlank(group.getOAuthPath()) && group.getOAuthPath().equals(groupUniqueId)) {
+        return true;
+      }
     }
     return false;
   }

--- a/src/main/java/com/simisinc/platform/presentation/controller/UserSession.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/UserSession.java
@@ -182,15 +182,19 @@ public class UserSession implements Serializable {
     return false;
   }
 
-  public boolean hasGroup(String uniqueId) {
+  public boolean hasGroup(String groupUniqueId) {
     if (groupList == null) {
       return false;
     }
-    if (StringUtils.isBlank(uniqueId)) {
+    if (StringUtils.isBlank(groupUniqueId)) {
       return false;
     }
     for (Group group : groupList) {
-      if (group.getUniqueId().equals(uniqueId)) {
+      if (group.getUniqueId().equals(groupUniqueId)) {
+        return true;
+      }
+      // If SSO is enabled, then also check against the "OAUTH" value in the group...
+      if (StringUtils.isNotBlank(group.getOAuthPath()) && group.getOAuthPath().equals(groupUniqueId)) {
         return true;
       }
     }

--- a/src/test/java/com/simisinc/platform/presentation/controller/UserSessionTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/UserSessionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 Matt Rajkowski (https://www.github.com/rajkowski)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.domain.model.Group;
+import com.simisinc.platform.domain.model.User;
+
+class UserSessionTest {
+  @Test
+  void testHasGroup() {
+
+    // Related user information
+    List<Group> userGroupList = new ArrayList<>();
+
+    Group testGroup = new Group("Testers", "testers");
+    testGroup.setOAuthPath("TESTERS");
+    userGroupList.add(testGroup);
+
+    Group reviewerGroup = new Group("Reviewers", "reviewers-1");
+    reviewerGroup.setOAuthPath("REVIEWERS");
+    userGroupList.add(reviewerGroup);
+
+    // User information
+    User user = new User();
+    user.setId(1L);
+    user.setGroupList(userGroupList);
+
+    // Log the user in
+    UserSession userSession = new UserSession();
+    userSession.login(user);
+
+    // User record
+    Assertions.assertTrue(user.hasGroup("testers"));
+    Assertions.assertTrue(user.hasGroup("TESTERS"));
+    Assertions.assertTrue(user.hasGroup("reviewers-1"));
+    Assertions.assertTrue(user.hasGroup("REVIEWERS"));
+    Assertions.assertFalse(user.hasGroup("reviewers"));
+    Assertions.assertFalse(user.hasGroup("user"));
+
+    // UserSession record
+    Assertions.assertTrue(userSession.hasGroup("testers"));
+    Assertions.assertTrue(userSession.hasGroup("TESTERS"));
+    Assertions.assertTrue(userSession.hasGroup("reviewers-1"));
+    Assertions.assertTrue(userSession.hasGroup("REVIEWERS"));
+    Assertions.assertFalse(userSession.hasGroup("reviewers"));
+    Assertions.assertFalse(userSession.hasGroup("user"));
+  }
+}


### PR DESCRIPTION
When using groups from OpenIDConnect it's now possible to reference the provided group values from widgets